### PR TITLE
Move .gitignore to project root and add Python ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+.cache/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+c
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+coverage
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# IntelliJ/Pycharm/Webstorm files
+.idea/
+
+# misc
+.DS_Store
+.env


### PR DESCRIPTION
I think the best practice for .gitignore is to have a single .gitignore file at the root of the project so I moved the .gitignore that was in `xcessiv/ui` (I think it was generated by create-react-scripts) to the project root and added some Python ignore lines.